### PR TITLE
Feature: support <source> nodes

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>lazyvids.js</title>
+  <link rel="icon"
+    href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🐢</text></svg>">
   <link rel="stylesheet" href="style.css">
   <script type="module" src="main.mjs"></script>
   <script>


### PR DESCRIPTION
# Overview
Adds support for `<video>` elements with file paths defined in child `<source>` nodes rather than directly on the `<video>` element with `src` attribute.