### PR TITLE
Ignore videos with `data-lazyvids="false"`

### DIFF
--- a/src/lazyvids.js
+++ b/src/lazyvids.js
@@ -155,7 +155,8 @@
     /**
      * Begin processing videos currently in the DOM.
      */
-    const domSelector = 'video[data-lazyvids]:not([data-lazyvids=loaded])';
+    const domSelector =
+      'video[data-lazyvids]:not([data-lazyvids=loaded]):not([data-lazyvids=false])';
     const lazyVideos = document.querySelectorAll(domSelector);
     log(
       `Initialised — ${lazyVideos.length} ${
@@ -177,7 +178,8 @@
           if (
             node.tagName === 'VIDEO' &&
             node.dataset.lazyvids !== undefined &&
-            node.dataset.lazyvids !== 'loaded'
+            node.dataset.lazyvids !== 'loaded' &&
+            node.dataset.lazyvids !== 'false'
           ) {
             process(node);
             return;


### PR DESCRIPTION
This PR enables setting `data-lazyvids="false"` to avoid being processed by lazyvids. This behaves the same as not having `data-lazyvids` set at all.

This is helpful for when `data-lazyvids` needs to be set as a boolean.