### PR TITLE
Remove `requirePoster`

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,6 +3,6 @@
   "semi": true,
   "tabWidth": 2,
   "singleQuote": true,
-  "printWidth": 80,
+  "printWidth": 120,
   "proseWrap": "never"
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ lazyvids.js works by setting attributes on HTML5 video elements, and playing the
 
 3. It's best practice to also include `muted` and `playsinline` attributes, but the library will add them by default.
 
-4. Provide the `<video>` with a `poster` image attribute. A poster image is required for the video to lazy-play by default, but this behaviour can be changed using the relevant `lazyvidsConfig` option.
+4. Provide the `<video>` with a `poster` image attribute.
 
 ```html
 <video
@@ -56,7 +56,6 @@ Configuration options are available using a `lazyvidsConfig` object on the globa
     ignoreHidden: false,
     minBandwidth: 0,
     reduceData: false,
-    requirePoster: true,
   };
 </script>
 ```
@@ -67,4 +66,3 @@ Configuration options are available using a `lazyvidsConfig` object on the globa
 | `ignoreHidden` | `boolean` | `false` | Set whether to skip `<video>` elements with `display: hidden`. |
 | `minBandwidth` | `number` | `0` | If `reduceData` is `true`, set threshold above which videos will play. |
 | `reduceData` | `boolean` | `false` | If `true`, will not play videos if data saver is enabled or bandwidth is below `minBandwidth`. |
-| `requirePoster` | `boolean` | `true` | When `false`, will lazy-play video even if poster image is missing. |

--- a/src/lazyvids.js
+++ b/src/lazyvids.js
@@ -8,17 +8,10 @@
      * Configuration options.
      */
     const config = {
-      logLevel: configObj && configObj.logLevel ? configObj.logLevel : 'silent',
-      ignoreHidden:
-        configObj && configObj.ignoreHidden ? configObj.ignoreHidden : false,
-      minBandwidth:
-        configObj && configObj.minBandwidth
-          ? Number.parseFloat(configObj.minBandwidth)
-          : 0,
-      reduceData:
-        configObj && configObj.reduceData ? configObj.reduceData : false,
-      requirePoster:
-        configObj && configObj.requirePoster ? configObj.requirePoster : true,
+      logLevel: configObj.logLevel ?? 'silent',
+      ignoreHidden: configObj.ignoreHidden ?? false,
+      minBandwidth: configObj.minBandwidth ? Number(configObj.minBandwidth) : 0,
+      reduceData: configObj.reduceData ?? false,
     };
 
     const log = (message, object = '') => {
@@ -130,16 +123,6 @@
      * handling <video> elements discovered in the DOM.
      */
     const process = (video) => {
-      // lazyvids videos must have a poster image (default)
-      if (
-        config.requirePoster &&
-        (video.poster === undefined || video.poster === '')
-      ) {
-        playVideo(video);
-        warn(`Video missing poster image. Lazy autoplay disabled for:`, video);
-        return;
-      }
-
       // IE fallback — no support for IntersectionObserver
       if (supportsIntersectionObserver === false) {
         playVideo(video);

--- a/src/lazyvids.js
+++ b/src/lazyvids.js
@@ -41,12 +41,11 @@
     /**
      * `playVideo()` is the last step, and main functionality.
      *
-     * Set autoplay, muted and playsinline attributes on the video,
-     * and start playing it with .play(). Update data-lazyvids attribute
+     * Set autoplay and muted attributes on the video, and start
+     * playing it with .play(). Update data-lazyvids attribute
      * value to prevent re-detecting the video for processing.
      */
     const playVideo = (video) => {
-      video.playsinline = true;
       video.muted = true;
       video.autoplay = true;
 

--- a/src/lazyvids.js
+++ b/src/lazyvids.js
@@ -8,10 +8,10 @@
      * Configuration options.
      */
     const config = {
-      logLevel: configObj.logLevel ?? 'silent',
-      ignoreHidden: configObj.ignoreHidden ?? false,
-      minBandwidth: configObj.minBandwidth ? Number(configObj.minBandwidth) : 0,
-      reduceData: configObj.reduceData ?? false,
+      logLevel: configObj?.logLevel ?? 'silent',
+      ignoreHidden: configObj?.ignoreHidden ?? false,
+      minBandwidth: configObj?.minBandwidth ? Number(configObj.minBandwidth) : 0,
+      reduceData: configObj?.reduceData ?? false,
     };
 
     const log = (message, object = '') => {
@@ -23,8 +23,7 @@
       window.console.warn(`lazyvids: ${message}`, object);
     };
 
-    const supportsIntersectionObserver =
-      typeof window.IntersectionObserver === 'function';
+    const supportsIntersectionObserver = typeof window.IntersectionObserver === 'function';
     let intersectionObserver;
 
     /**
@@ -33,14 +32,9 @@
     if (
       config.reduceData &&
       config.minBandwidth &&
-      navigator.connection &&
-      navigator.connection.downlink &&
-      (navigator.connection.downlink < config.minBandwidth ||
-        navigator.connection.saveData)
+      (navigator.connection?.downlink < config.minBandwidth || navigator.connection?.saveData)
     ) {
-      warn(
-        `Slow connection (${navigator.connection.downlink}mbps). Lazy autoplay disabled.`
-      );
+      warn(`Slow connection (${navigator.connection?.downlink}mbps). Lazy autoplay disabled.`);
       return;
     }
 
@@ -70,19 +64,8 @@
      * Utility function to check for video element visibility.
      */
     const isVisible = (element) => {
-      if (
-        element.style &&
-        element.style.display &&
-        element.style.display === 'none'
-      )
-        return false;
-      if (
-        config.ignoreHidden &&
-        element.style &&
-        element.style.visibility &&
-        element.style.visibility === 'hidden'
-      )
-        return false;
+      if (element.style?.display === 'none') return false;
+      if (config.ignoreHidden && element.style?.visibility === 'hidden') return false;
       const styles = getComputedStyle(element);
       const display = styles.getPropertyValue('display');
       if (display === 'none') return false;
@@ -90,8 +73,7 @@
         const visibility = styles.getPropertyValue('visibility');
         if (visibility === 'hidden') return false;
       }
-      if (element.parentNode && element.parentNode !== document)
-        return isVisible(element.parentNode);
+      if (element.parentNode && element.parentNode !== document) return isVisible(element.parentNode);
       return true;
     };
 
@@ -138,14 +120,9 @@
     /**
      * Begin processing videos currently in the DOM.
      */
-    const domSelector =
-      'video[data-lazyvids]:not([data-lazyvids=loaded]):not([data-lazyvids=false])';
+    const domSelector = 'video[data-lazyvids]:not([data-lazyvids=loaded]):not([data-lazyvids=false])';
     const lazyVideos = document.querySelectorAll(domSelector);
-    log(
-      `Initialised — ${lazyVideos.length} ${
-        lazyVideos.length === 1 ? 'video' : 'videos'
-      } detected`
-    );
+    log(`Initialised — ${lazyVideos.length} ${lazyVideos.length === 1 ? 'video' : 'videos'} detected`);
     lazyVideos.forEach((video) => process(video));
 
     /**
@@ -169,7 +146,6 @@
           }
           if (node.hasChildNodes() === false) return;
           const nestedLazyvids = node.querySelectorAll(domSelector);
-          if (nestedLazyvids.length === 0) return;
           nestedLazyvids.forEach((videoNode) => process(videoNode));
         });
       });


### PR DESCRIPTION
This PR removes the requirement for lazy-play videos to have a `poster` image assigned, as there's no benefit to this condition.